### PR TITLE
Bootstrap added a new file

### DIFF
--- a/src/tower/server/generator/generators/tower/app/appGenerator.coffee
+++ b/src/tower/server/generator/generators/tower/app/appGenerator.coffee
@@ -143,6 +143,7 @@ class Tower.Generator.AppGenerator extends Tower.Generator
           @get "https://raw.github.com/twitter/bootstrap/master/less/#{stylesheet}.less", "bootstrap/#{stylesheet}.less" for stylesheet in [
             "accordion",
             "alerts",
+            "badges",
             "bootstrap",
             "breadcrumbs",
             "button-groups",


### PR DESCRIPTION
So bootstrap.css wasn't compiling because of a missing dependency.
