### PR TITLE
Added test case for issue #92

### DIFF
--- a/test/cases/issues/issue92Test.coffee
+++ b/test/cases/issues/issue92Test.coffee
@@ -1,0 +1,34 @@
+attr = Tower.Model.Attribute
+
+describeWith = (store) ->
+  describe "Testing Issue #92. (Tower.Store.#{store.name})", ->
+    issue = null
+
+    beforeEach ->
+      issue = new App.Issue92()
+
+    test 'test for changing boolean values', (done) ->
+      assert.equal issue.get("enabled"), true
+
+      issue.set "enabled", false
+      assert.equal issue.get("enabled"), false
+
+      issue.save =>
+        App.Issue92.find issue.get("id"), (error, issue) =>
+          assert.equal issue.get("enabled"), false
+
+          issue.set "enabled", true
+          assert.equal issue.get("enabled"), true
+
+          issue.save =>
+            App.Issue92.find issue.get("id"), (error, issue) =>
+              assert.equal issue.get("enabled"), true
+
+              done()
+
+describeWith(Tower.Store.Memory)
+
+if Tower.client
+  describeWith(Tower.Store.Ajax)
+else
+  describeWith(Tower.Store.MongoDB)

--- a/test/example/app/models/issues/issue92.coffee
+++ b/test/example/app/models/issues/issue92.coffee
@@ -1,0 +1,2 @@
+class App.Issue92 extends Tower.Model
+  @field "enabled", type: "Boolean", default: true


### PR DESCRIPTION
This test case shows the error reported in issue #92.

A model field, that has a default value of true, can not be changed back to true once it was set to false.
