### PR TITLE
Return undefined when no record found and returnArray is false (ex. "first"/"last" is called)

### DIFF
--- a/src/tower/model/criteria.coffee
+++ b/src/tower/model/criteria.coffee
@@ -343,7 +343,7 @@ class Tower.Model.Criteria extends Tower.Class
       @store.findOne @, callback
     else
       @store.find @, (error, records) =>
-        records = @export(records) if !error && records.length
+        records = @export(records) if !error && records.length?
         callback.call @, error, records if callback
         records
 


### PR DESCRIPTION
Current Tower returns blank array when no records found for MyModel.first

ps.
Because here is JS world, zero is not true :p
