### PR TITLE
Made Tower.Support.String#pluralize and #singularize use Tower.modules.inflector

### DIFF
--- a/src/tower/support/string.coffee
+++ b/src/tower/support/string.coffee
@@ -20,28 +20,15 @@ Tower.Support.String =
           .replace('-', '_').toLowerCase()
 
   singularize: (string) ->
-    len = string.length
-    if string.substr(len - 3) is 'ies'
-      string.substr(0, len - 3) + 'y'
-    else if string.substr(len - 1) is 's'
-      string.substr(0, len - 1)
-    else
-      string
+    Tower.modules.inflector.singularize arguments...
 
   pluralize: (count, string) ->
     if string
       return string if count is 1
     else
       string = count
-
-    len = string.length
-    lastLetter = string.substr(len - 1)
-    if lastLetter is 'y'
-      "#{string.substr(0, len - 1)}ies"
-    else if lastLetter is 's'
-      string
-    else
-      "#{string}s"
+    
+    Tower.modules.inflector.pluralize string
 
   capitalize: (string) -> string.replace @capitalize_rx, (m,p1,p2) -> p1 + p2.toUpperCase()
 

--- a/test/cases/support/stringTest.coffee
+++ b/test/cases/support/stringTest.coffee
@@ -1,2 +1,18 @@
 describe 'Tower.Support.String', ->
+  describe 'inflection', ->
+    support = Tower.Support.String
+    
+    test 'pluralize', ->
+      assert.equal support.pluralize("entry"), "entries"
+      assert.equal support.pluralize("business"), "businesses"
+      assert.equal support.pluralize("people"), "people"
+      assert.equal support.pluralize("person"), "people"
+      assert.equal support.pluralize(2, "thing"), "things"
+      assert.equal support.pluralize(1, "thing"), "thing"
+      assert.equal support.pluralize(0, "thing"), "things"
+      
+    test 'singularize', ->
+      assert.equal support.singularize("businesses"), "business"
+      assert.equal support.singularize("people"), "person"
+      assert.equal support.singularize("person"), "person"
   


### PR DESCRIPTION
Also added Tower.Support.String tests for inflection. It's a bit unDRY since the format tests do the same thing, basically, on the `_` inclusions. Seems like some thought needs to go into clarifying the distinction (if there really is one) between Tower.Support.String and the additional methods added to `_`.
