### PR TITLE
Adjusts line in instrumentation.coffee breaking response headers due to params.format

### DIFF
--- a/src/tower/controller/instrumentation.coffee
+++ b/src/tower/controller/instrumentation.coffee
@@ -62,7 +62,8 @@ Tower.Controller.Instrumentation =
       @session  = @request.session  || {}
       
       unless @params.format
-        try @params.format = require('mime').extension(@request.header("content-type"))
+        console.log @request.header("content-type")
+        try @params.format = require('mime').extension(@controller.request.header("content-type"))
         @params.format ||= "html"
         
       @format   = @params.format


### PR DESCRIPTION
The code was causing params.format to return as format "form" in some situations, breaking the response and causing errors. This adjustment appears to solve the problem.  
