### PR TITLE
Fix asset paths for S3 uploads

### DIFF
--- a/lib/tower/server/application/assets.js
+++ b/lib/tower/server/application/assets.js
@@ -138,7 +138,6 @@ Tower.Application.Assets = {
       "Expires": expirationDate.toUTCString()
     };
     gzipHeaders = {
-      "Content-Encoding": "gzip",
       "Vary": "Accept-Encoding"
     };
     process.on('exit', function() {

--- a/lib/tower/server/generator/generators/tower/app/templates/cake
+++ b/lib/tower/server/generator/generators/tower/app/templates/cake
@@ -7,7 +7,9 @@ task 'assets:upload', ->
 task 'assets:upload:s3', ->
   invoke 'environment'
   
-  client  = knox.createClient Tower.config.credentials.s3
+  unless Tower.secrets
+    Tower.secrets = { s3: Tower.config.credentials.s3 }
+  client  = knox.createClient Tower.secrets.s3
   
   Tower.Application.Assets.upload (from, to, headers, callback) ->
     client.putFile from, to, headers, callback

--- a/lib/tower/view/helpers/assetHelper.js
+++ b/lib/tower/view/helpers/assetHelper.js
@@ -61,31 +61,31 @@ Tower.View.AssetHelper = {
           }
           if (Tower.assetHost) {
             if (Tower.assetHost.match(/^https?:\/{2}s3\./)) {
-            	switch(source.match(/[^\.]+$/)[0]) {
-            		case 'css':
-		          		source = "/stylesheets/" + source;
-		          		break;
-		          		
-		          	case 'js':
-		          		source = "/javascripts/" + source;
-		          		break;
-		          		
-		          	case 'jpg':
-		          	case 'gif':
-		          	case 'png':
+              switch(source.match(/[^\.]+$/)[0]) {
+              	case 'css':
+              	  source = "/stylesheets/" + source;
+              	  break;
+              	  
+              	case 'js':
+              	  source = "/javascripts/" + source;
+              	  break;
+              	  
+              	case 'jpg':
+                case 'gif':
+                case 'png':
                 case 'jpeg':
-		          		source = "/images/" + source;
-		          		break;
-		          		
-		          	default:
-		          		source = "/assets/" + source;
-		          		break;
-		          }
-          	}
+                  source = "/images/" + source;
+                  break;
+                  
+                default:
+                  source = "/assets/" + source;
+                  break;
+              }
+            }
             source = "" + Tower.assetHost + source;
           }
           else {
-          	source = "/assets/" + source;
+            source = "/assets/" + source;
           }
         }
         result.push(source);

--- a/lib/tower/view/helpers/assetHelper.js
+++ b/lib/tower/view/helpers/assetHelper.js
@@ -73,6 +73,7 @@ Tower.View.AssetHelper = {
 		          	case 'jpg':
 		          	case 'gif':
 		          	case 'png':
+                case 'jpeg':
 		          		source = "/images/" + source;
 		          		break;
 		          		

--- a/lib/tower/view/helpers/assetHelper.js
+++ b/lib/tower/view/helpers/assetHelper.js
@@ -61,8 +61,8 @@ Tower.View.AssetHelper = {
           }
           if (Tower.assetHost) {
             if (Tower.assetHost.match(/^https?:\/{2}s3\./)) {
-          		switch(source.match(/[^\.]+$/)[0]) {
-		          	case 'css':
+            	switch(source.match(/[^\.]+$/)[0]) {
+            		case 'css':
 		          		source = "/stylesheets/" + source;
 		          		break;
 		          		

--- a/lib/tower/view/helpers/assetHelper.js
+++ b/lib/tower/view/helpers/assetHelper.js
@@ -1,4 +1,3 @@
-
 Tower.View.AssetHelper = {
   javascripts: function() {
     var options, path, paths, sources, _i, _len;
@@ -60,9 +59,32 @@ Tower.View.AssetHelper = {
           if (manifest[source]) {
             source = manifest[source];
           }
-          source = "/assets/" + source;
           if (Tower.assetHost) {
+            if (Tower.assetHost.match(/^https?:\/{2}s3\./)) {
+          		switch(source.match(/[^\.]+$/)[0]) {
+		          	case 'css':
+		          		source = "/stylesheets/" + source;
+		          		break;
+		          		
+		          	case 'js':
+		          		source = "/javascripts/" + source;
+		          		break;
+		          		
+		          	case 'jpg':
+		          	case 'gif':
+		          	case 'png':
+		          		source = "/images/" + source;
+		          		break;
+		          		
+		          	default:
+		          		source = "/assets/" + source;
+		          		break;
+		          }
+          	}
             source = "" + Tower.assetHost + source;
+          }
+          else {
+          	source = "/assets/" + source;
           }
         }
         result.push(source);


### PR DESCRIPTION
Related to this issue: https://github.com/viatropos/tower/issues/138

Not the best fix, I think that file structure should be uniform both for local asset storage and s3 uploads. But I can't decide myself which structure is better, so leaving it as is for now.
