### PR TITLE
Fixes Issue 143-- chai.js had incorrect uri in appGenerator

### DIFF
--- a/lib/tower/server/generator/generators/tower/app/appGenerator.js
+++ b/lib/tower/server/generator/generators/tower/app/appGenerator.js
@@ -147,7 +147,7 @@ Tower.Generator.AppGenerator = (function(_super) {
           this.get("https://raw.github.com/viatropos/node.inflection/master/lib/inflection.js", "inflection.js");
           this.get("https://raw.github.com/josscrowcroft/accounting.js/master/accounting.js", "accounting.js");
           this.get("http://sinonjs.org/releases/sinon-1.3.1.js", "sinon.js");
-          this.get("https://raw.github.com/logicalparadox/chai/master/chai.js", "chai.js");
+          this.get("https://raw.github.com/chaijs/chai/master/chai.js", "chai.js");
           this.get("http://coffeekup.org/coffeekup.js", "coffeekup.js");
           this.get("https://raw.github.com/emberjs/starter-kit/cf5c6fa7c21c476f9441c220b16a63f37fe2cdc1/js/libs/ember-0.9.6.js", "ember.js");
           this.get("http://twitter.github.com/bootstrap/assets/js/google-code-prettify/prettify.js", "prettify.js");

--- a/src/tower/server/generator/generators/tower/app/appGenerator.coffee
+++ b/src/tower/server/generator/generators/tower/app/appGenerator.coffee
@@ -128,7 +128,7 @@ class Tower.Generator.AppGenerator extends Tower.Generator
           @get "https://raw.github.com/viatropos/node.inflection/master/lib/inflection.js", "inflection.js"
           @get "https://raw.github.com/josscrowcroft/accounting.js/master/accounting.js", "accounting.js"
           @get "http://sinonjs.org/releases/sinon-1.3.1.js", "sinon.js"
-          @get "https://raw.github.com/logicalparadox/chai/master/chai.js", "chai.js"
+          @get "https://raw.github.com/chaijs/chai/master/chai.js", "chai.js"
           @get "http://coffeekup.org/coffeekup.js", "coffeekup.js"
           @get "https://raw.github.com/emberjs/starter-kit/cf5c6fa7c21c476f9441c220b16a63f37fe2cdc1/js/libs/ember-0.9.6.js", "ember.js"
           @get "http://twitter.github.com/bootstrap/assets/js/google-code-prettify/prettify.js", "prettify.js"


### PR DESCRIPTION
Changed tower/src/tower/server/generator/generators/tower/app/appGenerator ln 131 to the new, correct line # to download chai.js. This fixes Issue #143.
