### PR TITLE
Flash messages

### DIFF
--- a/lib/tower/controller.js
+++ b/lib/tower/controller.js
@@ -40,6 +40,8 @@ Tower.Controller = (function(_super) {
 
 require('./controller/callbacks');
 
+require('./controller/flash');
+
 require('./controller/helpers');
 
 require('./controller/instrumentation');
@@ -57,6 +59,8 @@ require('./controller/responder');
 require('./controller/responding');
 
 Tower.Controller.include(Tower.Controller.Callbacks);
+
+Tower.Controller.include(Tower.Controller.Flash);
 
 Tower.Controller.include(Tower.Controller.Helpers);
 

--- a/lib/tower/controller/flash.js
+++ b/lib/tower/controller/flash.js
@@ -1,0 +1,21 @@
+
+Tower.Controller.Flash = {
+  InstanceMethods: {
+    flash: function(type, msg) {
+      var arr, msgs;
+      msgs = this.session.flash = this.session.flash || {};
+      if (type && msg) {
+        return msgs[type] = String(msg);
+      } else if (type) {
+        arr = msgs[type];
+        delete msgs[type];
+        return String(arr || "");
+      } else {
+        this.session.flash = {};
+        return msgs;
+      }
+    }
+  }
+};
+
+module.exports = Tower.Controller.Flash;

--- a/lib/tower/controller/rendering.js
+++ b/lib/tower/controller/rendering.js
@@ -137,6 +137,8 @@ Tower.Controller.Rendering = {
       options.prefixes || (options.prefixes = []);
       options.prefixes.push(this.collectionName);
       options.template || (options.template = options.file || (options.action || this.action));
+      options.locals || (options.locals = {});
+      options.locals.flash = this.flash();
       return options;
     }
   }

--- a/lib/tower/server/generator/generators/tower/app/appGenerator.js
+++ b/lib/tower/server/generator/generators/tower/app/appGenerator.js
@@ -62,6 +62,7 @@ Tower.Generator.AppGenerator = (function(_super) {
             return this.template("application.coffee");
           });
           return this.inside("shared", function() {
+            this.template("_flash.coffee");
             this.template("_footer.coffee");
             this.template("_header.coffee");
             this.template("_meta.coffee");

--- a/lib/tower/server/generator/generators/tower/app/templates/app/views/layouts/application.coffee
+++ b/lib/tower/server/generator/generators/tower/app/templates/app/views/layouts/application.coffee
@@ -18,7 +18,11 @@ html ->
     header id: "header", class: "header", role: "banner", ->
       div class: "container", ->
         partial "shared/header"
-        
+
+    section id: "flash", role: "banner", ->
+      div class: "container", ->
+        partial "shared/flash"
+
     section id: "content", role: "main", ->
       div class: "container", ->
         yields "body"

--- a/lib/tower/server/generator/generators/tower/app/templates/app/views/shared/_flash.coffee
+++ b/lib/tower/server/generator/generators/tower/app/templates/app/views/shared/_flash.coffee
@@ -1,0 +1,15 @@
+if @flash.error
+  div class: "alert alert-error", ->
+    a class: "close", data: {dismiss: "alert"}, href: "#", -> "x"
+    h1 "Error!"
+    h4 @flash.error
+if @flash.success
+  div class: "alert alert-success", ->
+    a class: "close", data: {dismiss: "alert"}, href: "#", -> "x"
+    h1 "Success!"
+    h4 @flash.success
+if @flash.info
+  div class: "alert alert-info", ->
+    a class: "close", data: {dismiss: "alert"}, href: "#", -> "x"
+    h1 "Important!"
+    h4 @flash.info

--- a/src/tower/controller.coffee
+++ b/src/tower/controller.coffee
@@ -35,6 +35,7 @@ class Tower.Controller extends Tower.Class
     @hasParent            = @constructor.hasParent()
 
 require './controller/callbacks'
+require './controller/flash'
 require './controller/helpers'
 require './controller/instrumentation'
 require './controller/params'
@@ -45,6 +46,7 @@ require './controller/responder'
 require './controller/responding'
 
 Tower.Controller.include Tower.Controller.Callbacks
+Tower.Controller.include Tower.Controller.Flash
 Tower.Controller.include Tower.Controller.Helpers
 Tower.Controller.include Tower.Controller.Instrumentation
 Tower.Controller.include Tower.Controller.Params

--- a/src/tower/controller/flash.coffee
+++ b/src/tower/controller/flash.coffee
@@ -1,0 +1,17 @@
+Tower.Controller.Flash = 
+
+  InstanceMethods:
+    # Both send and recieve flash messages
+    flash: (type, msg) ->
+      msgs = @session.flash = @session.flash || {}
+      if type && msg
+        msgs[type] = String msg
+      else if type
+        arr = msgs[type]
+        delete msgs[type]
+        String arr || ""
+      else
+        @session.flash = {}
+        msgs
+
+module.exports = Tower.Controller.Flash

--- a/src/tower/controller/rendering.coffee
+++ b/src/tower/controller/rendering.coffee
@@ -157,6 +157,8 @@ Tower.Controller.Rendering =
       options.prefixes  ||= []
       options.prefixes.push @collectionName
       options.template ||= (options.file || (options.action || @action))
+      options.locals ||= {}
+      options.locals.flash = @flash()
       options
 
 module.exports = Tower.Controller.Rendering

--- a/src/tower/server/generator/generators/tower/app/appGenerator.coffee
+++ b/src/tower/server/generator/generators/tower/app/appGenerator.coffee
@@ -43,6 +43,7 @@ class Tower.Generator.AppGenerator extends Tower.Generator
           @inside "layouts", ->
             @template "application.coffee"
           @inside "shared", ->
+            @template "_flash.coffee"
             @template "_footer.coffee"
             @template "_header.coffee"
             @template "_meta.coffee"


### PR DESCRIPTION
This pull request adds flash-messaging modeled loosely on a similar feature found in Rails and Express.  The primary method involved, flash(), was in fact modeled quite closely on a similar method found in Express, though its use within a Tower application has more in common with the Rails version (the developer can simply use the feature, without needing to add dynamic helpers or additional templating). 

To use, simply call the method from the controller with one of three types, "error", "success" or "info" along with a message to include.  Call this before rendering the page. 

The messages are currently templated in shared/_flash.coffee and styled, consistently with the rest of Tower, using Twitter-Bootstrap. Developers are, of course, free to change or remove the templating or styling as suits their particular needs.  _flash.coffee is called?/rendered? from layouts/application.coffee so changes to it may need to be adjusted there as well.  Will add example code and screenshots or links to screenshots to the wiki.
