### PR TITLE
Fix length validations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ tmtags
 ## VIM
 *.swp
 
+## Ctags
+.tags
+
 ## PROJECT::GENERAL
 coverage
 rdoc

--- a/lib/tower/model/validator/length.js
+++ b/lib/tower/model/validator/length.js
@@ -8,6 +8,8 @@ Tower.Model.Validator.Length = (function(_super) {
   Length.name = 'Length';
 
   function Length(name, value, attributes, options) {
+    name = this.valueCheck(name, value);
+    value = value[name] || (value[name] = value);
     Length.__super__.constructor.apply(this, arguments);
     this.validate = (function() {
       switch (name) {
@@ -32,6 +34,9 @@ Tower.Model.Validator.Length = (function(_super) {
   Length.prototype.validateGreaterThanOrEqual = function(record, attribute, errors, callback) {
     var value;
     value = record.get(attribute);
+    if (typeof value === 'string') {
+      value = value.length;
+    }
     if (!(value >= this.getValue(record))) {
       return this.failure(record, attribute, errors, Tower.t("model.errors.minimum", {
         attribute: attribute,
@@ -44,6 +49,9 @@ Tower.Model.Validator.Length = (function(_super) {
   Length.prototype.validateGreaterThan = function(record, attribute, errors, callback) {
     var value;
     value = record.get(attribute);
+    if (typeof value === 'string') {
+      value = value.length;
+    }
     if (!(value > this.getValue(record))) {
       return this.failure(record, attribute, errors, Tower.t("model.errors.minimum", {
         attribute: attribute,
@@ -56,6 +64,9 @@ Tower.Model.Validator.Length = (function(_super) {
   Length.prototype.validateLessThanOrEqual = function(record, attribute, errors, callback) {
     var value;
     value = record.get(attribute);
+    if (typeof value === 'string') {
+      value = value.length;
+    }
     if (!(value <= this.getValue(record))) {
       return this.failure(record, attribute, errors, Tower.t("model.errors.minimum", {
         attribute: attribute,
@@ -68,6 +79,9 @@ Tower.Model.Validator.Length = (function(_super) {
   Length.prototype.validateLessThan = function(record, attribute, errors, callback) {
     var value;
     value = record.get(attribute);
+    if (typeof value === 'string') {
+      value = value.length;
+    }
     if (!(value < this.getValue(record))) {
       return this.failure(record, attribute, errors, Tower.t("model.errors.minimum", {
         attribute: attribute,
@@ -80,6 +94,9 @@ Tower.Model.Validator.Length = (function(_super) {
   Length.prototype.validateMinimum = function(record, attribute, errors, callback) {
     var value;
     value = record.get(attribute);
+    if (typeof value === 'string') {
+      value = value.length;
+    }
     if (!(typeof value === 'number' && value >= this.getValue(record))) {
       return this.failure(record, attribute, errors, Tower.t("model.errors.minimum", {
         attribute: attribute,
@@ -92,6 +109,9 @@ Tower.Model.Validator.Length = (function(_super) {
   Length.prototype.validateMaximum = function(record, attribute, errors, callback) {
     var value;
     value = record.get(attribute);
+    if (typeof value === 'string') {
+      value = value.length;
+    }
     if (!(typeof value === 'number' && value <= this.getValue(record))) {
       return this.failure(record, attribute, errors, Tower.t("model.errors.maximum", {
         attribute: attribute,
@@ -104,6 +124,9 @@ Tower.Model.Validator.Length = (function(_super) {
   Length.prototype.validateLength = function(record, attribute, errors, callback) {
     var value;
     value = record.get(attribute);
+    if (typeof value === 'string') {
+      value = value.length;
+    }
     if (!(typeof value === 'number' && value === this.getValue(record))) {
       return this.failure(record, attribute, errors, Tower.t("model.errors.length", {
         attribute: attribute,
@@ -111,6 +134,18 @@ Tower.Model.Validator.Length = (function(_super) {
       }), callback);
     }
     return this.success(callback);
+  };
+
+  Length.prototype.valueCheck = function(name, value) {
+    var key;
+    if (typeof value === 'object') {
+      for (key in value) {
+        if (key === "min" || key === "max" || key === "gte" || key === "gt" || key === "lte" || key === "lt") {
+          return key;
+        }
+      }
+    }
+    return name;
   };
 
   return Length;

--- a/src/tower/model/validator/length.coffee
+++ b/src/tower/model/validator/length.coffee
@@ -1,5 +1,7 @@
 class Tower.Model.Validator.Length extends Tower.Model.Validator
   constructor: (name, value, attributes, options) ->
+    name = @valueCheck name, value
+    value = value[name] ||= value
     super
 
     @validate = switch name
@@ -14,6 +16,8 @@ class Tower.Model.Validator.Length extends Tower.Model.Validator
 
   validateGreaterThanOrEqual: (record, attribute, errors, callback) ->
     value = record.get(attribute)
+    if typeof value is 'string'
+      value = value.length
     unless value >= @getValue(record)
       return @failure(
         record,
@@ -26,6 +30,8 @@ class Tower.Model.Validator.Length extends Tower.Model.Validator
 
   validateGreaterThan: (record, attribute, errors, callback) ->
     value = record.get(attribute)
+    if typeof value is 'string'
+      value = value.length
     unless value > @getValue(record)
       return @failure(
         record,
@@ -38,6 +44,8 @@ class Tower.Model.Validator.Length extends Tower.Model.Validator
 
   validateLessThanOrEqual: (record, attribute, errors, callback) ->
     value = record.get(attribute)
+    if typeof value is 'string'
+      value = value.length
     unless value <= @getValue(record)
       return @failure(
         record,
@@ -50,6 +58,8 @@ class Tower.Model.Validator.Length extends Tower.Model.Validator
 
   validateLessThan: (record, attribute, errors, callback) ->
     value = record.get(attribute)
+    if typeof value is 'string'
+      value = value.length
     unless value < @getValue(record)
       return @failure(
         record,
@@ -62,6 +72,8 @@ class Tower.Model.Validator.Length extends Tower.Model.Validator
 
   validateMinimum: (record, attribute, errors, callback) ->
     value = record.get(attribute)
+    if typeof value is 'string'
+      value = value.length
     unless typeof(value) == 'number' && value >= @getValue(record)
       return @failure(
         record,
@@ -74,7 +86,8 @@ class Tower.Model.Validator.Length extends Tower.Model.Validator
 
   validateMaximum: (record, attribute, errors, callback) ->
     value = record.get(attribute)
-
+    if typeof value is 'string'
+      value = value.length
     unless typeof(value) == 'number' && value <= @getValue(record)
       return @failure(
         record,
@@ -87,6 +100,8 @@ class Tower.Model.Validator.Length extends Tower.Model.Validator
 
   validateLength: (record, attribute, errors, callback) ->
     value = record.get(attribute)
+    if typeof value is 'string'
+      value = value.length
     unless typeof(value) == 'number' && value == @getValue(record)
       return @failure(
         record,
@@ -96,5 +111,12 @@ class Tower.Model.Validator.Length extends Tower.Model.Validator
         callback
       )
     @success(callback)
+
+  valueCheck: (name, value) ->
+    if typeof value == 'object'
+      for key of value
+        if key in ["min", "max", "gte", "gt", "lte", "lt"]
+          return key
+    return name
 
 module.exports = Tower.Model.Validator.Length


### PR DESCRIPTION
This pull-request brings the length validations in line with how they work in Rails, and how the documentation suggests it should work.  Before, it was working as a simple number validation, testing whether a number met a simple boolean test. Used on fields that contained a string simply failed every time.

However, in rails the length validation is primarily used to measure the length of a string, ie. to count against the number of characters used and reject, for instance, a password that is too short, or a text entry that is too long. 

To give a short example of how they work now, take the case of a tweet on twitter which can't be longer than 140 characters. So, in your "messages model" you might have:

``` coffeescript
class App.Message extends Tower.Model
  @field "userId", type: "Integer"
  @field "tweet", type: "String"

  @validates 'tweet', length: { max: 140 }

  @belongsTo "user"

  @timestamps()
```

Now, tweets longer than 140 characters will fail.  If you logged the user.errors in your controller, you'd see the message:

```
'tweet must be a maximum of 140'
```

You could easily show these messages to your user, using the flash, once that is available, although as you can see, the current error messages need a little tweaking.  

Instead of simply changing the length validation to expect a string, I gave it a simple test, so that something like:

```
@validates 'age', length: { min: 21 }
```

will still work on a number.  Also, simply using 'length' by itself does an equals check so that:

```
@validates 'tweet', length: 140 
```

would expect a tweet of exactly 140 characters long.  

The easiest solution I currently see to the clumsiness of the error messages would be to fall back on the fact that max/min and gte/lte are redundant, so we could word the max/min errors with language talking about the number of characters and the gte/lte errors with language talking about numbers.  The documentation actually refers to a "numericality" class of validations which would handle all the number stuff, including gte/lte, etc, leaving 'length' to work solely with strings, which is how rails does it. Once that is implemented, they would each have their own default error message and this wouldn't be a problem either.

Also, currently there is no easy way for the developer to alter the error message from the default, though the documentation suggests its as simple as setting:

```
 @validates 'tweet', length: { max: 140, message: '%{count} characters is the maximum allowed'  }
```

I'm not sure if the implementation of this has been attempted and just isn't working properly or not. But, the ability to do this would be another potential solution to the clumsy error messages. For now, though, the length validations will do the correct thing and the error messages, though a bit clumsy, will describe the problem.
