### PR TITLE
fixes not being able to stop redirect using helper functions

### DIFF
--- a/src/tower/controller/tst.coffee
+++ b/src/tower/controller/tst.coffee
@@ -56,7 +56,7 @@ _.request = (method, path, options, callback) ->
   options   ||= {}
   headers     = options.headers || {}
   params      = options.params  || {}
-  redirects   = options.redirects || 5
+  redirects   = if options.redirects? then options.redirects else 5
   auth        = options.auth
   format      = options.format# || "form-data"
 


### PR DESCRIPTION
``` javascript
it "should be able to log in", (done) ->
  _.get '/auth/facebook', redirects: 0, (response) ->
    response.status.should.equal 302
    done()
```

Before this fix the status would be `200` as it followed a redirect regardless, because of the code below (and the way javascript handles `0 || something`):

``` javascript
redirects   = options.redirects || 5
```

After this fix, it's correct and is `302`
