### PR TITLE
hardcoded url in redirectTo removed

### DIFF
--- a/packages/tower-controller/shared/redirecting.coffee
+++ b/packages/tower-controller/shared/redirecting.coffee
@@ -20,11 +20,11 @@ Tower.ControllerRedirecting =
         url ||= '/'
 
         # @todo remove
-        if Tower.env == 'test'
-          if options.action == 'index'
-            url = '/custom'
-          else
-            url = "/custom/#{@resource.get('id')}"
+        # if Tower.env == 'test'
+        #   if options.action == 'index'
+        #     url = '/custom'
+        #   else
+        #     url = "/custom/#{@resource.get('id')}"
 
         @response.redirect url
       catch error


### PR DESCRIPTION
Zombiejs was crashing because of this, and integration testing was failing in a very fun way
