### PR TITLE
Updating package.json for windows cli support with npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,6 @@
   "scripts": {
     "test": "make test",
     "docs": "codo",
-    "postinstall": "npm install \"git://github.com/viatropos/coffeecup.git\" --force && npm install \"git://github.com/viatropos/coffee-script.git\" --force"
+    "postinstall": "npm install git://github.com/viatropos/coffeecup.git --force && npm install git://github.com/viatropos/coffee-script.git --force"
   }
 }


### PR DESCRIPTION
npm install was breaking when getting to postinstall, this fixed it on my machine. Windows 7 x64
