### PR TITLE
Flash client

### DIFF
--- a/packages/tower-controller/client.coffee
+++ b/packages/tower-controller/client.coffee
@@ -6,6 +6,7 @@ require './client/events'
 require './client/handlers'
 require './client/instrumentation'
 require './client/states'
+require './client/flash'
 
 Tower.Controller.include Tower.ControllerActions
 Tower.Controller.include Tower.ControllerElements
@@ -13,3 +14,4 @@ Tower.Controller.include Tower.ControllerEvents
 Tower.Controller.include Tower.ControllerHandlers
 Tower.Controller.include Tower.ControllerInstrumentation
 Tower.Controller.include Tower.ControllerStates
+Tower.Controller.include Tower.ControllerFlash

--- a/packages/tower-controller/client/flash.coffee
+++ b/packages/tower-controller/client/flash.coffee
@@ -1,0 +1,19 @@
+Tower.ControllerFlash =
+  InstanceMethods:
+    # Both send and recieve flash messages
+
+    flash: (type, msg) ->
+      msgs = $.jStorage.get("flash", {})
+      if type && msg
+        msgs[type] = String msg
+        $.jStorage.set("flash", msgs)
+      else if type
+        arr = msgs[type]
+        delete msgs[type]
+        $.jStorage.set("flash", msgs)
+        String arr || ""
+      else
+        $.jStorage.set("flash", {})
+        msgs
+
+module.exports = Tower.ControllerFlash

--- a/packages/tower-controller/client/instrumentation.coffee
+++ b/packages/tower-controller/client/instrumentation.coffee
@@ -18,6 +18,7 @@ Tower.ControllerInstrumentation =
   enterAction: (action) ->
     Ember.changeProperties =>
       @set('action', action)
+      @set('getFlash', @flash())
       @set(_.toStateName(action), true)
 
   # Called when the route for this controller is found.

--- a/packages/tower-generator/server/generators/tower/app/templates/config/assets.coffee
+++ b/packages/tower-generator/server/generators/tower/app/templates/config/assets.coffee
@@ -27,7 +27,7 @@ module.exports =
       '/vendor/javascripts/socket.io'
       '/vendor/javascripts/handlebars'
       '/vendor/javascripts/ember'
-      '/vendor/javascripts/jstorage.js'
+      '/vendor/javascripts/jstorage'
       '/vendor/javascripts/tower'
       # '/vendor/javascripts/uri'
       # '/vendor/javascripts/bootstrap/bootstrap-transition'

--- a/packages/tower-generator/server/generators/tower/view/templates/_flash.coffee
+++ b/packages/tower-generator/server/generators/tower/view/templates/_flash.coffee
@@ -1,0 +1,20 @@
+text '{{#if getFlash.error}}'
+div class: "alert alert-error", ->
+  a class: "close", data: {dismiss: "alert"}, href: "#", -> "x"
+  h1 "Error!"
+  h4 '{{getFlash.error}}'
+text '{{/if}}'
+
+text '{{#if getFlash.success}}'
+div class: "alert alert-success", ->
+  a class: "close", data: {dismiss: "alert"}, href: "#", -> "x"
+  h1 "Success!"
+  h4 '{{getFlash.success}}'
+text '{{/if}}'
+
+text '{{#if getFlash.info}}'
+div class: "alert alert-info", ->
+  a class: "close", data: {dismiss: "alert"}, href: "#", -> "x"
+  h1 "Important!"
+  h4 '{{getFlash.info}}'
+text '{{/if}}'

--- a/packages/tower-generator/server/generators/tower/view/templates/edit.coffee
+++ b/packages/tower-generator/server/generators/tower/view/templates/edit.coffee
@@ -1,5 +1,6 @@
 @title = "Editing <%= model.className %>"
 
+partial "flash"
 partial "form"
 
 contentFor "sidebar", ->

--- a/packages/tower-generator/server/generators/tower/view/templates/index.coffee
+++ b/packages/tower-generator/server/generators/tower/view/templates/index.coffee
@@ -1,3 +1,4 @@
 @title = "Listing <%= model.namePlural %>"
 
+partial "flash"
 partial "table"

--- a/packages/tower-generator/server/generators/tower/view/templates/new.coffee
+++ b/packages/tower-generator/server/generators/tower/view/templates/new.coffee
@@ -1,3 +1,4 @@
 @title = "New <%= model.className %>"
 
+partial "flash"
 partial "form"

--- a/packages/tower-generator/server/generators/tower/view/templates/show.coffee
+++ b/packages/tower-generator/server/generators/tower/view/templates/show.coffee
@@ -1,5 +1,7 @@
 @title = "<%= model.humanName %>"
 
+partial "flash"
+
 text '{{#with resource}}'
 dl class: "content", -><% for (var i = 0; i < model.attributes.length; i++) { %>
   dt "<%= model.attributes[i].humanName %>:"

--- a/packages/tower-generator/server/generators/tower/view/viewGenerator.coffee
+++ b/packages/tower-generator/server/generators/tower/view/viewGenerator.coffee
@@ -5,6 +5,7 @@ class Tower.GeneratorViewGenerator extends Tower.Generator
     @directory "app/views/#{@view.directory}"
 
     views = [
+      '_flash'
       '_form'
       '_item'
       '_list'


### PR DESCRIPTION
Adds the flash to the client side of Tower.  There is a little bit more necessary to use it, but the api is essentially the same. To use it on the index action, of a client-side users controller for instance, you can use:

``` coffeescript
index:(params) ->    
  @findCollection (error, collection) =>
    @flash 'info', 'Hello!'
    @flash 'error', 'Warning! Danger Will Robinson'
    @flash 'success', 'Yay! You did it!'
    @set('getFlash', @flash())      
    @render 'index'
```

Just like the example in the docs for the server side controller, these look the same, and this example will cause all three to appear.  The difference in this situation is that after setting the flash, and before render is called, you have to essentially "prime" the flash with:

``` coffeescript
@set('getFlash', @flash()) 
```

This is due to fundamental differences between how the two types of controller's operate, and out of everything I came up with, was the simplest solution requiring the least code.

A very cool feature of the way these works is that you can also call it from an action on the view, take the "submit" action in the form view, for example:

``` coffeescript
  submit: (event) ->
    @get('resource').save()
    users = App.router.get('usersController')
    users.flash 'success', 'Yay! You made a user!'
    Tower.router.transitionTo('users.index')
    return false
```

To set this one, you have to use the router's "get" method to grab the controller first, and call the method on the router. Also, I haven't used it in an action that doesnt cause a transition, but I imagine that the flash would not show up until the next time the UI was repainted. You could probably call something forcing the UI to re-render though, if you needed to use the flash yet keep the user on the same page. Experimentation must ensue. The odd thing here, in this particular case, it only works IF you've manually defined the action on the controller that the action is transitioning to.  This is simple enough, in my case I simply copied the default action from tower / packages / tower-controller / client / actions.coffee:

``` coffeescript
index: (params) ->
  @findCollection (error, collection) =>
    @render 'index'
```

When I update the docs, I'll include these for reference.  Again, a little more work to use than the server-side versions, but still much easier than rolling your own, and keeping to the same API. I really tried to make them exactly the same but as far as I can tell it's not possible without re-writing a lot more of tower than I'm comfortable doing, and even then, I wouldn't be sure how to do it.

Will update the docs soon, and do more experimenting so I can include more examples, but for the most part it should act work mostly like the originals.  Also, the server side API still works for those using server side routing/rendering.
