### PR TITLE
Fix root routing in ember

### DIFF
--- a/packages/tower-net/client/states.coffee
+++ b/packages/tower-net/client/states.coffee
@@ -120,7 +120,8 @@ Tower.Router = Ember.Router.extend
 
         # @todo tmp hack
         if r[i] == r[0] || r[i] == 'new'
-          routeName += r[i]
+          if r[i] != 'root'
+            routeName += r[i]
 
         # @todo tmp hack
         # Basically, create methods like `showUser` and `indexUsers`, which


### PR DESCRIPTION
For some reason / was being transformed to /root this aims to work around that. I don't know enough about the integration of everything to make this more elegant.
