### PR TITLE
add retries to Tower.GeneratorActions.get()

### DIFF
--- a/packages/tower-generator/server/actions.coffee
+++ b/packages/tower-generator/server/actions.coffee
@@ -18,11 +18,16 @@ File.mkdirpSync = (dir) ->
         console.error(e)
 
 Tower.GeneratorActions =
-  get: (url, to) ->
+  get: (url, to, retries=0) ->
     path  = @destinationPath(to)
 
-    error = ->
-      console.log "Error downloading #{url}"
+    error = =>
+      if retries > 3
+        console.log "Error downloading #{url}"
+      else
+        retries++
+        @get(url, to, retries)
+        
 
     request = Tower.module('superagent').get(url).buffer(true)
     # Cache buster so if the author uploads newer version to same path


### PR DESCRIPTION
Sometimes `tower new app` will fail to create the local copy of tower.js in the app. 

As best as I can tell this is because it's being served out of CloudFront, which may fail (?) to serve a request for an expired file. A simple retry or two should do the trick.
