### PR TITLE
Fixed path error for windows (maybe other os)

### DIFF
--- a/bin/tower
+++ b/bin/tower
@@ -2,7 +2,7 @@
 
 var fs = require('fs');
 var path = require('path');
-var script = path.join(process.env.PWD, 'scripts', 'tower');
+var script = path.join(process.cwd(), 'scripts' , 'tower');
 
 if (fs.existsSync(script)) {
   require(script);


### PR DESCRIPTION
When your inside a Tower application and use `tower ...` it would return an error saying that `scripts\tower` not found, but obviously it was there. Windows has a different beginning path and so `process.env.PWD` returned null but `process.cwd()` was successful. 
