### PR TITLE
Windows Testing Fix & tower-application(js)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-SRC = $(shell find test/cases -name client -prune -o -name '*Test.coffee' -print)
+#SRC = $(shell find test/cases -name client -prune -o -name '*Test.coffee' -print)
+SRC = $(shell node test/find.js test/cases/**/*.coffee)
 STORES = memory mongodb
 CMD = node_modules/mocha/bin/mocha
 DIR = $(shell pwd)

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   "devDependencies": {
   },
   "testDependencies": {
+    "glob-whatev": "*",
     "coffee-script": "~1.3.3",
     "stylus": ">= 0.29.0",
     "uglify-js": ">= 1.1.1",
@@ -116,7 +117,8 @@
     "ttys": "0.0.3",
     "cheerio": ">= 0.10.0",
     "Faker": ">= 0.1.3",
-    "colors": "~0.6.0-1"
+    "colors": "~0.6.0-1",
+    "testem": "*"
   },
   "globalDependencies": {},
   "localDependencies": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "devDependencies": {
   },
   "testDependencies": {
-    "glob-whatev": "*",
+    "glob-whatev": "0.1.8",
     "coffee-script": "~1.3.3",
     "stylus": ">= 0.29.0",
     "uglify-js": ">= 1.1.1",
@@ -117,8 +117,7 @@
     "ttys": "0.0.3",
     "cheerio": ">= 0.10.0",
     "Faker": ">= 0.1.3",
-    "colors": "~0.6.0-1",
-    "testem": "*"
+    "colors": "~0.6.0-1"
   },
   "globalDependencies": {},
   "localDependencies": {

--- a/packages/tower-application/client.js
+++ b/packages/tower-application/client.js
@@ -1,0 +1,2 @@
+require('./shared');
+require('./client/application');

--- a/packages/tower-application/client/application.js
+++ b/packages/tower-application/client/application.js
@@ -1,0 +1,75 @@
+/**
+global error handling
+
+$(window).error (event) ->
+  try
+    App.errorHandler(event)
+  catch error
+    console.log(error)
+**/
+
+var __hasProp = {}.hasOwnProperty,
+  __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+
+Tower.Application = (function(_super) {
+
+  __extends(Application, _super);
+
+  function Application() {
+    return Application.__super__.constructor.apply(this, arguments);
+  }
+
+  Application.reopenClass({
+    _callbacks: {},
+    instance: function() {
+      return this._instance;
+    }
+  });
+
+  Application.before('initialize', 'setDefaults');
+
+  Application.reopen({
+    setDefaults: function() {
+      return true;
+    },
+    teardown: function() {
+      return Tower.Route.reload();
+    },
+    init: function() {
+      this._super.apply(this, arguments);
+      if (Tower.Application._instance) {
+        throw new Error("Already initialized application");
+      }
+      return Tower.Application._instance = this;
+    },
+    ready: function() {
+      return this._super.apply(this, arguments);
+    },
+    initialize: function() {
+      this.extractAgent();
+      this.setDefaults();
+      this._super(Tower.router);
+      return this;
+    },
+    extractAgent: function() {
+      Tower.cookies = Tower.NetCookies.parse();
+      return Tower.agent = new Tower.NetAgent(JSON.parse(Tower.cookies["user-agent"] || '{}'));
+    },
+    listen: function() {
+      if (this.listening) {
+        return;
+      }
+      this.listening = true;
+      Tower.url || (Tower.url = "" + window.location.protocol + "//" + window.location.host);
+      Tower.socketUrl || (Tower.socketUrl = Tower.url);
+      Tower.NetConnection.initialize();
+      return Tower.NetConnection.listen(Tower.socketUrl);
+    },
+    run: function() {
+      return this.listen();
+    }
+  });
+
+  return Application;
+
+})(Tower.Engine);

--- a/packages/tower-application/server.js
+++ b/packages/tower-application/server.js
@@ -1,0 +1,4 @@
+require('./shared');
+require('./server/application');
+require('./server/assets');
+require('./server/watcher');

--- a/packages/tower-application/server/application.js
+++ b/packages/tower-application/server/application.js
@@ -1,0 +1,415 @@
+var fs, io, server, _, _path,
+  __hasProp = {}.hasOwnProperty,
+  __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+
+fs = require('fs');
+_path = require('path');
+server = null;
+io = null;
+_ = Tower._;
+Tower.tcpPort = 6969;
+Tower.Application = (function(_super) {
+
+  __extends(Application, _super);
+
+  function Application() {
+    return Application.__super__.constructor.apply(this, arguments);
+  }
+
+  Application.reopenClass({
+    _callbacks: {},
+    autoloadPaths: ['app/helpers', 'app/concerns', 'app/models', 'app/controllers', 'app/presenters', 'app/services', 'app/mailers', 'app/abilities', 'app/middleware', 'app/jobs'],
+    configNames: ['session', 'assets', 'credentials', 'databases', 'routes'],
+    instance: function() {
+      var app;
+      if (!this._instance) {
+        app = require("" + Tower.root + "/app/config/shared/application");
+        this._instance || (this._instance = app.create());
+      }
+      return this._instance;
+    },
+    initializers: function() {
+      return this._initializers || (this._initializers = []);
+    }
+  });
+
+  Application.before('initialize', 'setDefaults');
+
+  Application.reopen({
+    paths: [],
+    pathsByType: {},
+    setDefaults: function() {
+      return true;
+    },
+    errorHandlers: [],
+    init: function() {
+      if (Tower.Application._instance) {
+        throw new Error('Already initialized application');
+      }
+      this.app || (this.app = require('express')());
+      this.server = require('http').createServer(this.app);
+      Tower.Application._instance = this;
+      return this._super.apply(this, arguments);
+    },
+    initialize: function(config, complete) {
+      var initializer, type,
+        _this = this;
+      this._loadBase();
+      type = typeof config;
+      if (type !== 'object') {
+        if (type === 'function') {
+          complete = config;
+          config = {};
+        } else {
+          config = {};
+        }
+      }
+      type = null;
+      initializer = function(done) {
+        _this._loadPreinitializers();
+        _this._loadConfig(config);
+        _this._loadAssets();
+        _this._loadLocales();
+        _this._loadEnvironment();
+        _this._loadInitializers();
+        return _this.configureStores(Tower.config.databases, function() {
+          if (!Tower.isConsole) {
+            _this.stack();
+          }
+          if (!Tower.lazyLoadApp) {
+            return _this._loadApp(done);
+          } else {
+            done();
+            return process.nextTick(function() {
+              return _this._loadApp();
+            });
+          }
+        });
+      };
+      return this.runCallbacks('initialize', initializer, complete);
+    },
+    teardown: function() {
+      this.server.stack.length = 0;
+      return Tower.Route.clear();
+    },
+    handle: function() {
+      var _ref;
+      return (_ref = this.app).handle.apply(_ref, arguments);
+    },
+    use: function() {
+      var app, args, express, middleware;
+      args = _.args(arguments);
+      express = require('express');
+      app = this.app;
+      if (typeof args[0] === 'string') {
+        middleware = args.shift();
+        return app.use(express[middleware].apply(express, args));
+      } else {
+        return app.use.apply(app, args);
+      }
+    },
+    configureStores: function(configuration, callback) {
+      var databaseNames, defaultDatabase, defaultStoreSet, iterator,
+        _this = this;
+      if (configuration == null) {
+        configuration = {};
+      }
+      defaultStoreSet = false;
+      databaseNames = _.keys(configuration);
+      defaultDatabase = configuration["default"];
+      iterator = function(databaseName, next) {
+        var databaseConfig, store, storeClassName;
+        if (databaseName === 'default') {
+          return next();
+        }
+        databaseConfig = configuration[databaseName];
+        storeClassName = "Tower.Store" + (_.camelize(databaseName));
+        try {
+          store = Tower.constant(storeClassName);
+        } catch (error) {
+          store = require("" + __dirname + "/../../tower-store/server/" + databaseName);
+        }
+        if (defaultDatabase != null) {
+          if (databaseName === defaultDatabase) {
+            Tower.Model["default"]('store', store);
+            defaultStoreSet = true;
+          }
+        } else {
+          if (!defaultStoreSet || databaseConfig["default"]) {
+            if (!Tower.Model["default"]('store')) {
+              Tower.Model["default"]('store', store);
+            }
+            defaultStoreSet = true;
+          }
+        }
+        try {
+          store.configure(Tower.config.databases[databaseName][Tower.env]);
+        } catch (_error) {}
+        return store.initialize(next);
+      };
+      return Tower.parallel(databaseNames, iterator, function() {
+        if (!defaultStoreSet) {
+          console.log('Default database not set, using Memory store');
+        }
+        if (callback) {
+          return callback.call(_this);
+        }
+      });
+    },
+    stack: function() {
+      var config, configs, _i, _len;
+      if (this.isStacked) {
+        return this;
+      }
+      this.isStacked = true;
+      configs = this.constructor.initializers();
+      for (_i = 0, _len = configs.length; _i < _len; _i++) {
+        config = configs[_i];
+        config.call(this);
+      }
+      return this;
+    },
+    get: function() {
+      var _ref;
+      return (_ref = this.app).get.apply(_ref, arguments);
+    },
+    post: function() {
+      var _ref;
+      return (_ref = this.app).post.apply(_ref, arguments);
+    },
+    put: function() {
+      var _ref;
+      return (_ref = this.app).put.apply(_ref, arguments);
+    },
+    listen: function() {
+      var _this = this;
+      if (Tower.env !== 'test') {
+        this.app.on('error', function(error) {
+          if (error.errno === 'EADDRINUSE') {
+            console.log('   Try using a different port: `node server -p 3001`');
+            return process.exit();
+          }
+        });
+        this.initializeSockets();
+        return this.server.listen(Tower.port, function() {
+          var key, value;
+          console.info("Tower " + Tower.env + " server listening on port " + Tower.port);
+          for (key in _this) {
+            value = _this[key];
+            if (key.match(/(Controller)$/)) {
+              value.applySocketEventHandlers();
+            }
+          }
+          if (Tower.watch) {
+            _this.watch();
+          }
+          if (Tower.env === 'development') {
+            return _this.initializeServerHooks();
+          }
+        });
+      }
+    },
+    initializeSockets: function() {
+      if (!this.io) {
+        Tower.NetConnection.initialize();
+        return this.io = Tower.NetConnection.listen(this.server);
+      }
+    },
+    initializeConsoleHooks: function() {},
+    initializeServerHooks: function() {},
+    run: function() {
+      this.initialize();
+      return this.listen();
+    },
+    watch: function() {
+      return Tower.ApplicationWatcher.watch();
+    },
+    _loadBase: function() {
+      this._requireAny('app/config', 'application');
+      return this._requireAny('app/config', 'bootstrap');
+    },
+    _loadPreinitializers: function() {
+      return this._requirePaths(this.selectPaths('app/config', 'preinitializers'));
+    },
+    _loadConfig: function(options) {
+      var config, databases, defaultDatabase, key, _base, _i, _len, _ref;
+      _ref = this.constructor.configNames;
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        key = _ref[_i];
+        config = this._requireFirst('app/config', key) || {};
+        if (_.isPresent(config)) {
+          Tower.config[key] = config;
+        }
+      }
+      (_base = Tower.config).databases || (_base.databases = {});
+      databases = options.databases || options.database;
+      defaultDatabase = options.defaultDatabase;
+      if (databases) {
+        if (!(databases instanceof Array)) {
+          databases = [databases];
+        }
+        databases.push('default');
+        Tower.config.databases = _.pick(Tower.config.databases, databases);
+        if (defaultDatabase != null) {
+          return Tower.config.databases["default"] = defaultDatabase;
+        }
+      }
+    },
+    _loadAssets: function() {
+      return Tower.ApplicationAssets.loadManifest();
+    },
+    _loadLocales: function() {
+      var path, _i, _len, _ref, _results;
+      _ref = this.selectPaths('app/config', 'locales');
+      _results = [];
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        path = _ref[_i];
+        _results.push(Tower.SupportI18n.load(path));
+      }
+      return _results;
+    },
+    _loadEnvironment: function() {
+      return this._requireAny('app/config', "environments/" + Tower.env);
+    },
+    _loadInitializers: function() {
+      return this._requirePaths(this.selectPaths('app/config', 'initializers'));
+    },
+    _loadMVC: function() {
+      var path, _i, _len, _ref, _results;
+      _ref = this.constructor.autoloadPaths;
+      _results = [];
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        path = _ref[_i];
+        if (path.match('app/controllers')) {
+          this._requireAny('app/controllers', 'applicationController');
+        }
+        _results.push(this._requirePaths(this.selectPaths(path)));
+      }
+      return _results;
+    },
+    _loadApp: function(done) {
+      this._loadMVC();
+      Tower.isInitialized = true;
+      if (done) {
+        return done();
+      }
+    },
+    requireDirectory: function(path, type) {
+      var file, files, pattern, wrench, _i, _len, _ref;
+      if (type == null) {
+        type = 'script';
+      }
+      wrench = Tower.module('wrench');
+      pattern = this._typeToPattern[type];
+      _ref = files = wrench.readdirSyncRecursive(path);
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        file = _ref[_i];
+        if (file.match(pattern)) {
+          require(_path.join(Tower.root, path, file));
+        }
+      }
+      return files;
+    },
+    _requirePaths: function(paths) {
+      var path, _i, _len, _results;
+      _results = [];
+      for (_i = 0, _len = paths.length; _i < _len; _i++) {
+        path = paths[_i];
+        _results.push(require(path));
+      }
+      return _results;
+    },
+    _requireAny: function(pathStart, pathEnd) {
+      var path, _i, _len, _ref, _results;
+      _ref = this._buildRequirePaths(pathStart, pathEnd);
+      _results = [];
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        path = _ref[_i];
+        _results.push(this._tryToRequire(path));
+      }
+      return _results;
+    },
+    _requireFirst: function(pathStart, pathEnd) {
+      var path, result, _i, _len, _ref;
+      _ref = this._buildRequirePaths(pathStart, pathEnd);
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        path = _ref[_i];
+        result = this._tryToRequire(path);
+        if (result != null) {
+          return result;
+        }
+      }
+      return null;
+    },
+    _buildRequirePaths: function(pathStart, pathEnd) {
+      return [_path.join(Tower.root, pathStart, pathEnd), _path.join(Tower.root, pathStart, 'shared', pathEnd), _path.join(Tower.root, pathStart, 'server', pathEnd)];
+    },
+    _tryToRequire: function(path) {
+      try {
+        return require(path);
+      } catch (error) {
+        if (Tower.debug) {
+          console.error(error);
+        }
+        return null;
+      }
+    },
+    selectPaths: function(pathStart, pathEnd, type) {
+      var clientDir, index, key, paths, pattern, requirePath, wrench, _i, _len, _ref;
+      if (type == null) {
+        type = 'script';
+      }
+      key = this._pathCacheKey(pathStart, pathEnd);
+      paths = this.pathsByType[key];
+      if (paths != null) {
+        return paths;
+      }
+      paths = [];
+      wrench = Tower.module('wrench');
+      pattern = this._typeToPattern[type];
+      _ref = this._buildRequirePaths(pathStart, pathEnd);
+      for (index = _i = 0, _len = _ref.length; _i < _len; index = ++_i) {
+        requirePath = _ref[index];
+        if (!fs.existsSync(requirePath)) {
+          continue;
+        }
+        if (index === 0) {
+          clientDir = new RegExp(_.regexpEscape(_path.join(requirePath, 'client')), 'g');
+          paths = paths.concat(_.select(this._selectNestedPaths(requirePath, wrench.readdirSyncRecursive(requirePath)), function(path) {
+            return !path.match(clientDir);
+          }));
+        } else {
+          paths = paths.concat(this._selectNestedPaths(requirePath, wrench.readdirSyncRecursive(requirePath)));
+        }
+      }
+      return this.pathsByType[key] = _.select(paths, function(path) {
+        return path.match(pattern);
+      });
+    },
+    _selectNestedPaths: function(dir, paths) {
+      return _.select(_.map(paths, function(path) {
+        return _path.join(dir, path);
+      }), function(path) {
+        return !fs.statSync(path).isDirectory();
+      });
+    },
+    _typeToPattern: {
+      script: /\.(coffee|js|iced)$/,
+      stylesheet: /\.(css|less|styl|sass)$/,
+      template: /\.(jade|ejs|handlebars|html|eco|coffee)/
+    },
+    _pathCacheKey: function(pathStart, pathEnd) {
+      var key;
+      key = pathStart;
+      if (pathEnd != null) {
+        key += "," + pathEnd;
+      }
+      return key;
+    }
+  });
+
+  return Application;
+
+})(Tower.Engine);
+
+module.exports = Tower.Application;

--- a/packages/tower-application/server/assets.js
+++ b/packages/tower-application/server/assets.js
@@ -1,0 +1,228 @@
+var fs, path, _, _path;
+
+fs = require('fs');
+path = require('path');
+_path = require('path');
+_ = Tower._;
+
+Tower.ApplicationAssets = {
+  loadManifest: function() {
+    try {
+      return Tower.assetManifest = JSON.parse(Tower.readFileSync('public/asset-manifest.json', 'utf-8'));
+    } catch (error) {
+      return Tower.assetManifest = {};
+    }
+  },
+  bundle: function(options) {
+    var bundle, bundleIterator, bundles, gzip, manifest, mint;
+    if (options == null) {
+      options = {};
+    }
+    gzip = require('gzip');
+    mint = Tower.module('mint');
+    if (!options.hasOwnProperty('minify')) {
+      options.minify = true;
+    }
+    manifest = {};
+    bundle = function(type, extension, compressor, callback) {
+      var assetBlocks, assets, compile, name, paths;
+      assets = Tower.config.assets[type];
+      compile = function(data, next) {
+        var content, name, paths, writeFile, _i, _len;
+        name = data.name, paths = data.paths;
+        console.log("Bundling public/" + type + "/" + name + extension);
+        content = '';
+        for (_i = 0, _len = paths.length; _i < _len; _i++) {
+          path = paths[_i];
+          content += Tower.readFileSync(Tower.join('public', "" + type + path + extension), 'utf-8') + "\n\n";
+        }
+        writeFile = function(content) {
+          var digestPath, fingerprint;
+          fingerprint = Tower.fingerprint(content);
+          digestPath = Tower.pathWithFingerprint(Tower.join('public', "" + type + "/" + name + extension), fingerprint);
+          manifest["" + name + extension] = Tower.basename(digestPath);
+          return Tower.writeFile(digestPath, content, function() {
+            return process.nextTick(next);
+          });
+        };
+        if (options.minify) {
+          return compressor(content, {}, function(error, content) {
+            if (error) {
+              console.log(error);
+              return next(error);
+            }
+            return writeFile(content);
+          });
+        } else {
+          return writeFile(content);
+        }
+      };
+      assetBlocks = [];
+      for (name in assets) {
+        paths = assets[name];
+        assetBlocks.push({
+          name: name,
+          paths: paths
+        });
+      }
+      return Tower.async(assetBlocks, compile, callback);
+    };
+    bundleIterator = function(data, next) {
+      return bundle(data.type, data.extension, data.compressor, next);
+    };
+    bundles = [
+      {
+        type: "stylesheets",
+        extension: ".css",
+        compressor: mint.yui
+      }, {
+        type: "javascripts",
+        extension: ".js",
+        compressor: mint.uglifyjs
+      }
+    ];
+    return process.nextTick(function() {
+      return Tower.async(bundles, bundleIterator, function(error) {
+        if (error) {
+          throw error;
+        }
+        console.log('Writing public/asset-manifest.json');
+        return Tower.writeFile("public/asset-manifest.json", JSON.stringify(manifest, null, 2), function() {
+          return process.nextTick(function() {
+            return process.exit();
+          });
+        });
+      });
+    });
+  },
+  upload: function(block) {
+    var assetCache, cacheHeaders, cachePath, config, expirationDate, fonts, gzip, gzipHeaders, images, javascripts, paths, stylesheets, upload;
+    gzip = require('gzip');
+    cachePath = 'tmp/asset-cache.json';
+    if (!Tower.existsSync('tmp')) {
+      fs.mkdirSync('tmp');
+    }
+    try {
+      assetCache = Tower.existsSync(cachePath) ? JSON.parse(Tower.readFileSync(cachePath, 'utf-8')) : {};
+    } catch (error) {
+      console.log(error.message);
+      assetCache = {};
+    }
+    config = (function() {
+      try {
+        return Tower.config.credentials.s3;
+      } catch (_error) {}
+    })();
+    if (config && config.bucket) {
+      console.log("Uploading to " + config.bucket);
+    }
+    images = _.select(Tower.files('public/images'), function(path) {
+      return !!path.match(/\.(gif|ico|png|jpg)$/i);
+    });
+    fonts = _.select(Tower.files('public/fonts'), function(path) {
+      return !!path.match(/\.(tff|woff|svg|eot)$/i);
+    });
+    stylesheets = _.select(Tower.files('public/assets'), function(path) {
+      return !!path.match(/-[a-f0-9]+\.(css)$/i);
+    });
+    javascripts = _.select(Tower.files('public/assets'), function(path) {
+      return !!path.match(/-[a-f0-9]+\.(js)$/i);
+    });
+    paths = _.map(images.concat(fonts).concat(stylesheets).concat(javascripts), function(path) {
+      return path.replace(/^public\//, "");
+    });
+    expirationDate = new Date();
+    expirationDate.setTime(expirationDate.getTime() + 1000 * 60 * 60 * 24 * 365);
+    cacheHeaders = {
+      'Cache-Control': 'public',
+      'Expires': expirationDate.toUTCString()
+    };
+    gzipHeaders = {};
+    process.on('exit', function() {
+      return Tower.writeFileSync(cachePath, JSON.stringify(assetCache, null, 2));
+    });
+    process.on('SIGINT', function() {
+      return process.exit();
+    });
+    upload = function(path, next) {
+      var cached, headers;
+      console.log("Uploading /" + path);
+      headers = _.extend({}, cacheHeaders);
+      if (!!path.match(/^(stylesheets|javascripts)/)) {
+        headers = _.extend(headers, gzipHeaders, {
+          'Etag': Tower.pathFingerprint(path)
+        });
+      } else {
+        headers = _.extend(headers, {
+          'Etag': Tower.digestPathSync("public/" + path)
+        });
+      }
+      cached = assetCache[path];
+      if (!(cached && cached['Etag'] === headers['Etag'])) {
+        cached = _.extend({}, headers);
+        return block("public/" + path, "/" + path, headers, function(error, result) {
+          if (error) {
+            console.log(error);
+          }
+          return process.nextTick(function() {
+            assetCache[path] = cached;
+            return next(error);
+          });
+        });
+      } else {
+        return next();
+      }
+    };
+    return Tower.async(paths, upload, function(error) {
+      if (error) {
+        console.log(error);
+      }
+      return process.nextTick(function() {
+        return Tower.writeFile(cachePath, JSON.stringify(assetCache, null, 2), function() {
+          return process.nextTick(function() {
+            return process.exit();
+          });
+        });
+      });
+    });
+  },
+  uploadToS3: function(callback) {
+    var client, knox;
+    knox = require('knox');
+    client = knox.createClient(Tower.config.credentials.s3);
+    return this.upload(function(from, to, headers, next) {
+      return client.putFile(from, to, headers, next);
+    });
+  },
+  stats: function() {
+    var Table, big, compressedSize, manifest, normalSize, percent, small, stat, table;
+    Table = require('cli-table');
+    manifest = Tower.assetManifest;
+    table = new Table({
+      head: ['Path', 'Compressed (kb)', 'Normal (kb)', '%'],
+      colWidths: [60, 20, 20, 10]
+    });
+    for (big in manifest) {
+      small = manifest[big];
+      path = "public/assets/" + small;
+      stat = Tower.statSync(path);
+      compressedSize = stat.size / 1000.0;
+      path = "public/assets/" + big;
+      stat = Tower.statSync(path);
+      normalSize = stat.size / 1000.0;
+      percent = (1 - (compressedSize / normalSize)) * 100.0;
+      percent = percent.toFixed(1);
+      compressedSize = compressedSize.toFixed(1);
+      normalSize = normalSize.toFixed(1);
+      if ((compressedSize === normalSize && normalSize === '0.0')) {
+        percent = '-';
+      } else {
+        percent = "" + percent + "%";
+      }
+      table.push([path, compressedSize, normalSize, percent]);
+    }
+    return console.log(table.toString());
+  }
+};
+
+module.exports = Tower.ApplicationAssets;

--- a/packages/tower-application/server/platform.js
+++ b/packages/tower-application/server/platform.js
@@ -1,0 +1,8 @@
+
+Tower.__defineGetter__('isHeroku', function() {
+  return process.env.TOWER_CLOUD_PLATFORM === 'heroku';
+});
+
+Tower.__defineGetter__('isNodejitsu', function() {
+  return process.env.TOWER_CLOUD_PLATFORM === 'nodejitsu';
+});

--- a/packages/tower-application/server/watcher.js
+++ b/packages/tower-application/server/watcher.js
@@ -1,0 +1,223 @@
+var fs, _, _path;
+
+_path = require('path');
+fs = require('fs');
+_ = Tower._;
+
+Tower.ApplicationWatcher = {
+  reloadMap: {
+    models: {
+      pattern: /app\/models/,
+      paths: []
+    },
+    controllers: {
+      pattern: /app\/controllers/,
+      paths: []
+    },
+    helpers: {
+      pattern: /app\/helpers/,
+      paths: []
+    }
+  },
+  checkIfGruntIsWatching: function() {
+    var child, forever,
+      _this = this;
+    return;
+    forever = require('forever');
+    child = new forever.Monitor('grunt.coffee', {
+      max: 1,
+      silent: false,
+      options: []
+    });
+    child.start();
+    child.on('stdout', function(data) {});
+    child.on('error', function(error) {
+      return console.log(error);
+    });
+    return forever.startServer(child);
+  },
+  watch: function() {
+    var chokidar, clientPath, directories, watcher,
+      _this = this;
+    chokidar = require('chokidar');
+    directories = ['app', 'config', 'public'];
+    clientPath = new RegExp(_.regexpEscape(_path.join('app', 'client')));
+    watcher = chokidar.watch(directories, {
+      ignored: function(path) {
+        if (path.match(/\./)) {
+          return !path.match(/\.(js|coffee|iced|styl)$/);
+        } else {
+          return !path.match(/(app|config|public)/);
+        }
+      },
+      persistent: true
+    });
+    return watcher.on('add', function(path) {
+      return _this.fileCreated(_path.resolve(Tower.root, path));
+    }).on('change', function(path) {
+      path = _path.resolve(Tower.root, path);
+      if (fs.existsSync(path)) {
+        if (!Tower.Application.instance().isConsole && (path.match(Tower.publicPath) || path.match(/\.styl$/))) {
+          return _this.clientFileUpdated(path);
+        } else {
+          if (!path.match(new RegExp(_.regexpEscape("" + _path.sep + "client" + _path.sep)))) {
+            return _this.fileUpdated(path);
+          }
+        }
+      } else {
+        return _this.fileDeleted(path);
+      }
+    }).on('unlink', function(path) {
+      return _this.fileDeleted(_path.resolve(Tower.root, path));
+    }).on('error', function(error) {
+      return this;
+    });
+  },
+  clientFileCreated: function(path) {
+    return this._clientFileChanged('fileCreated', path, fs.readFileSync(path, 'utf-8'));
+  },
+  clientFileUpdated: function(path) {
+    return this._clientFileChanged('fileUpdated', path, fs.readFileSync(path, 'utf-8'));
+  },
+  _clientFileChanged: function(action, path, content) {
+    var data;
+    data = {
+      path: _path.relative(Tower.root, path)
+    };
+    if (content != null) {
+      if (path.match(/\.styl$/)) {
+        content = require('mint').stylus(content, {});
+        data.path = 'stylesheets/' + data.path.replace(/\.styl$/, '.css');
+      }
+      data.content = content;
+    }
+    data.url = '/' + data.path.replace(new RegExp(_.regexpEscape(_path.sep), 'g'), '/').replace(/^public\//, '');
+    return Tower.Application.instance().io.sockets.emit(action, JSON.stringify(data, this._jsonReplacer));
+  },
+  _jsonReplacer: function(key, value) {
+    if (value instanceof RegExp) {
+      return "(function() { return new RegExp('" + value + "') })";
+    } else if (typeof value === "function") {
+      return "(" + value + ")";
+    } else {
+      return value;
+    }
+  },
+  fileCreated: function(path) {
+    if (path.match('app/views')) {
+      return;
+    }
+    try {
+      return require.resolve(path);
+    } catch (error) {
+      return require(path);
+    }
+  },
+  fileDeleted: function(path) {
+    return delete require.cache[require.resolve(path)];
+  },
+  fileUpdated: function(path) {
+    var app, directory, index, isController, key, klass, klassName, language, name, pattern, subclasses, value, _i, _j, _len, _len1, _ref,
+      _this = this;
+    app = Tower.Application.instance();
+    if (!app.isInitialized) {
+      app._loadApp();
+    }
+    pattern = function(string) {
+      return new RegExp(_.regexpEscape(string));
+    };
+    if (path.match(pattern(_path.join('app', 'templates')))) {
+      return Tower.View.cache = {};
+    } else if (path.match(pattern(_path.join('app', 'helpers')))) {
+      return this.reloadPath(path, function() {
+        return _this.reloadPaths(_path.join(Tower.root, 'app', 'controllers'));
+      });
+    } else if (path.match(pattern(_path.join('config/server', 'assets.coffee')))) {
+      return this.reloadPath(path, function(error, config) {
+        Tower.config.assets = config || {};
+        return Tower.ApplicationAssets.loadManifest();
+      });
+    } else if (path.match(/app\/(models|controllers)\/.+\.(?:coffee|js|iced)/)) {
+      isController = RegExp.$1 === 'controllers';
+      directory = "app/" + RegExp.$1;
+      klassName = path.split('/');
+      klassName = klassName[klassName.length - 1];
+      klassName = klassName.split('.');
+      klassName.pop();
+      klassName = klassName.join('.');
+      klassName = _.camelize(klassName);
+      klass = (function() {
+        try {
+          return Tower.constant(klassName);
+        } catch (_error) {}
+      })();
+      if (!klass) {
+        return require(path);
+      } else {
+        app = Tower.Application.instance();
+        subclasses = [];
+        _ref = _.keys(app);
+        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+          key = _ref[_i];
+          value = app[key];
+          if (klass !== value && klass.detect(value)) {
+            subclasses.push(key);
+          }
+        }
+        for (index = _j = 0, _len1 = subclasses.length; _j < _len1; index = ++_j) {
+          name = subclasses[index];
+          subclasses[index] = _path.join(directory, _.camelize(name, true));
+        }
+        return this.reloadPath(path, function() {
+          return _this.reloadPaths(subclasses, function() {
+            var paths, _k, _len2, _results;
+            if (isController) {
+              paths = Tower.Application.instance()._buildRequirePaths('app/config', 'routes');
+              _results = [];
+              for (_k = 0, _len2 = paths.length; _k < _len2; _k++) {
+                path = paths[_k];
+                try {
+                  _results.push(_this.reloadPath(path));
+                } catch (_error) {}
+              }
+              return _results;
+            }
+          });
+        });
+      }
+    } else if (path.match(/config\/(server|shared)\/routes\.(?:coffee|js|iced)/)) {
+      return this.reloadPath(path);
+    } else if (path.match(/config\/(server|shared)\/locales\/(\w+)\.(?:coffee|js|iced)/)) {
+      language = RegExp.$1;
+      return this.reloadPath(path, function(error, locale) {
+        return Tower.SupportI18n.load(locale, language);
+      });
+    }
+  },
+  reloadPath: function(path, callback) {
+    path = require.resolve(_path.resolve(Tower.root, _path.relative(Tower.root, path)));
+    delete require.cache[path];
+    return process.nextTick(function() {
+      var result;
+      result = require(path);
+      if (callback) {
+        return callback(null, result);
+      }
+    });
+  },
+  reloadPaths: function(directory, callback) {
+    var path, _i, _len, _ref;
+    _ref = Tower.files(directory);
+    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+      path = _ref[_i];
+      if (path.match(/\.(?:coffee|js|iced)$/)) {
+        this.reloadPath(path);
+      }
+    }
+    if (callback) {
+      return process.nextTick(function() {
+        return callback();
+      });
+    }
+  }
+};

--- a/packages/tower-application/shared.js
+++ b/packages/tower-application/shared.js
@@ -1,0 +1,2 @@
+require('./shared/hook');
+require('./shared/engine');

--- a/packages/tower-application/shared/engine.js
+++ b/packages/tower-application/shared/engine.js
@@ -1,0 +1,36 @@
+var __hasProp = {}.hasOwnProperty,
+  __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+
+Tower.Engine = (function(_super) {
+
+  __extends(Engine, _super);
+
+  function Engine() {
+    return Engine.__super__.constructor.apply(this, arguments);
+  }
+
+  Engine.configure = function(block) {
+    return this.initializers().push(block);
+  };
+
+  Engine.initializers = function() {
+    return this._initializers || (this._initializers = []);
+  };
+
+  Engine.prototype.configure = function(block) {
+    return this.constructor.configure(block);
+  };
+
+  Engine.prototype.subscribe = function(key, block) {
+    Tower.ModelCursor.subscriptions.push(key);
+    return this[key] = typeof block === 'function' ? block() : block;
+  };
+
+  Engine.prototype.unsubscribe = function(key) {
+    Tower.ModelCursor.subscriptions.splice(_.indexOf(key), 1);
+    return delete this[key];
+  };
+
+  return Engine;
+
+})(Tower.Hook);

--- a/packages/tower-application/shared/hook.js
+++ b/packages/tower-application/shared/hook.js
@@ -1,0 +1,16 @@
+var __hasProp = {}.hasOwnProperty,
+  __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+
+Tower.Hook = (function(_super) {
+
+  __extends(Hook, _super);
+
+  function Hook() {
+    return Hook.__super__.constructor.apply(this, arguments);
+  }
+
+  Hook.include(Tower.SupportCallbacks);
+
+  return Hook;
+
+})(Ember.Application);

--- a/packages/tower-application/shared/locale/da.js
+++ b/packages/tower-application/shared/locale/da.js
@@ -1,0 +1,13 @@
+module.exports = {
+  errors: {
+    missingCallback: "Du skal sende en callback til %s.",
+    missingOption: "Du skal sende en '%s' option til %s.",
+    notFound: "%s ikke fundet.",
+    store: {
+      missingAttribute: "Mangler %s i %s for '%s'"
+    },
+    asset: {
+      notFound: "Asset ikke fundet: '%s'\n  Søgestier: [\n%s\n  ]"
+    }
+  }
+};

--- a/packages/tower-application/shared/locale/en.js
+++ b/packages/tower-application/shared/locale/en.js
@@ -1,0 +1,14 @@
+
+module.exports = {
+  errors: {
+    missingCallback: "You must pass a callback to %s.",
+    missingOption: "You must pass in the '%s' option to %s.",
+    notFound: "%s not found.",
+    store: {
+      missingAttribute: "Missing %s in %s for '%s'"
+    },
+    asset: {
+      notFound: "Asset not found: '%s'\n  Lookup paths: [\n%s\n  ]"
+    }
+  }
+};

--- a/packages/tower-application/shared/locale/ptBr.js
+++ b/packages/tower-application/shared/locale/ptBr.js
@@ -1,0 +1,13 @@
+module.exports = {
+  errors: {
+    missingCallback: "Você deve passar um callback para %s.",
+    missingOption: "Você deve passar a opção '%s' para %s.",
+    notFound: "%s não encontrado.",
+    store: {
+      missingAttribute: "Faltando %s no %s para '%s'"
+    },
+    asset: {
+      notFound: "Asset não encontrado: '%s'\n  Paths procurados: [\n%s\n  ]"
+    }
+  }
+};

--- a/test/find.js
+++ b/test/find.js
@@ -1,0 +1,8 @@
+var globsync = require('glob-whatev');
+var output = "";
+
+globsync.glob(process.argv[2]).forEach(function(filepath){
+	output += " " + filepath;
+});
+
+console.log(output);


### PR DESCRIPTION
Since windows doesn't support any unix commands, I made a simple node script that does the same thing, but works with globs (like gruntjs) instead. 

`node test/find.js test/cases/**/*Test.coffee` is the default command being run instead of the unix variant. The 2 parameter is the glob to find. 

I was gonna make this a pull request for the master branch but it would've included your original js convertion.
