### PR TITLE
set validation: validate as fine if we have null instead of iterable

### DIFF
--- a/packages/tower-model/shared/validator/set.coffee
+++ b/packages/tower-model/shared/validator/set.coffee
@@ -5,7 +5,7 @@ class Tower.ModelValidatorSet extends Tower.ModelValidator
     value     = record.get(attribute)
     testValue = @getValue(record)
 
-    success = switch @name
+    success = testValue is null or switch @name
       when 'in'
         _.indexOf(testValue, value) > -1
       when 'notIn'


### PR DESCRIPTION
Rationale: now I can skip/abort the validation conditionally such as with the
following:

```
  in: ->
    if @get('country') == 'CA'
      ['ON', 'QC', 'NS', 'NB', 'MB', 'BC', 'PE', 'SK', 'AB', 'NL', 'NT', 'YT', 'NU']
    else
      null
```

What do you think of this? This functionality would definitely be nice but maybe you have a different idea of how it should be implemented.
