### PR TITLE
fix agent detection bug: TypeError: Object Mac OS X 10.8.2 has no method 'match'

### DIFF
--- a/packages/tower-middleware/server/agent.coffee
+++ b/packages/tower-middleware/server/agent.coffee
@@ -9,9 +9,9 @@ Tower.MiddlewareAgent = (request, response, next) ->
     version:  agent.toVersion()
     os:       agent.os
     name:     agent.toAgent()
-    mac:      !!agent.os.match(/mac/i)
-    windows:  !!agent.os.match(/win/i)
-    linux:    !!agent.os.match(/linux/i)
+    mac:      !!agent.os.family.match(/mac/i)
+    windows:  !!agent.os.family.match(/win/i)
+    linux:    !!agent.os.family.match(/linux/i)
 
   request.agent = new Tower.NetAgent(attributes)
 


### PR DESCRIPTION
fix exception:
TypeError: Object Mac OS X 10.8.2 has no method 'match'
    at Object.Tower.MiddlewareAgent [as handle](/home/erundook/towertest/node_modules/tower/packages/tower-middleware/server/agent.coffee:14:23)
